### PR TITLE
fixed exception on esc key pressed

### DIFF
--- a/js/greeter.js
+++ b/js/greeter.js
@@ -722,7 +722,7 @@ class AntergosTheme {
 		_self.selected_user = null;
 		_self.auth_pending = false;
 
-		if ( $(event.target).hasClass('alert') ) {
+		if ( !!event && $(event.target).hasClass('alert') ) {
 			/* We were triggered by the authentication failed message being dismissed.
 			 * Keep the same account selected so user can retry without re-selecting an account.
 			 */


### PR DESCRIPTION
Since the `cancel_authentication` handler can be triggered without providing the event argument, a blocking exception could be raised, causing the default theme loading that raises another exception because it's scripts tries to access the `lightdm` object before it's injection.

Checking if the event argument exist in `cancel_authentication` solves the issue.